### PR TITLE
docs: add CLAUDE.md with project context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# IA-FIC-IFSP
+
+Material do curso FIC **"Introdução à IA para Tomada de Decisão"** — IFSP Piracicaba, 2021/2 em diante. Repo é **scaffolding pedagógico**, não código de produção.
+
+## Estrutura
+
+- 12 aulas (`Aula_00` … `Aula_12`) + 3 atividades (`Atividade_0x`), cada uma autoexplicativa.
+- Cada `Aula_*/README.md` linka aulas no YouTube (vídeo é a fonte primária; código é companion).
+- Mix de `.ipynb` (Jupyter) e `.py` standalone.
+
+## Stack
+
+Python 3.x + pandas, numpy, scikit-learn, TensorFlow/Keras, OpenCV. Pontual: Gradio (UI), LangChain (Aula_11 RAG, precisa `OPENAI_API_KEY` em `.env`), SAM v2 + YOLO11 (Aula_12).
+
+- **Sem `requirements.txt` central** — cada aula assume libs pré-instaladas no env. Para reproduzir sem dor, usar `conda env` por aula quando alguma versão briga.
+- **Pesos de modelo grandes ignorados** (`.pt`, `.onnx`, ~450 MB SAM/YOLO). Baixar conforme a aula.
+- **Gabaritos ignorados** no `.gitignore` (`*gabarito*`).
+
+## Como trabalhar aqui
+
+- Aulas têm dependência temática: Aula_00 (Python básico) → Aula_12 (CV + LLM). Não assumir conceito de aula posterior.
+- README em PT-BR; código mistura PT/EN nos comentários.
+- Mudanças em material didático: priorizar **clareza > performance**, pseudocódigo onde fizer sentido.
+- Não há test suite — verificação é rodar o notebook end-to-end.
+
+## Env
+
+Neste notebook: conda env `base` (Python 3.13) costuma servir. Para CV/LLM (Aulas 11–12), criar env dedicado para evitar conflito de versões.


### PR DESCRIPTION
## Summary

Adiciona `CLAUDE.md` com contexto do repo para sessões do Claude Code. Stub focado no que não é óbvio do README.

- Estrutura por aula (Aula_00 → Aula_12 + Atividades), dependência temporal entre tópicos
- Stack multi-tópico (CV / LLM com deps conflitantes — recomendar conda env por aula nas mais pesadas)
- Sem `requirements.txt` central
- Pesos de modelo grandes (`.pt`, `.onnx`) ignorados — ~450 MB SAM/YOLO
- Gabaritos ignorados no `.gitignore`
- Mix PT/EN nos comentários
- Vídeo-first: README de cada aula linka aulas no YouTube; código é companion

## Test plan

- [x] Arquivo criado em `/CLAUDE.md`
- [ ] Revisar conteúdo (sugestões/correções bem-vindas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)